### PR TITLE
Ask for original content type instead of "default"

### DIFF
--- a/bundle/Controller/LocationController.php
+++ b/bundle/Controller/LocationController.php
@@ -45,7 +45,10 @@ class LocationController extends Controller
 
     public function suggestedAction(Request $request, $content)
     {
-        if (!isset($this->contentConfiguration[$content]) && $content != 'default') {
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($content);
+        $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, reset($this->languages));
+
+        if (!isset($this->contentConfiguration[$content])) {
             $content = 'default';
         }
 
@@ -54,9 +57,6 @@ class LocationController extends Controller
         } else {
             $locations = [];
         }
-
-        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($content);
-        $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, reset($this->languages));
 
         $suggested = [];
         foreach ($locations as $locationId) {

--- a/bundle/Controller/LocationController.php
+++ b/bundle/Controller/LocationController.php
@@ -43,17 +43,17 @@ class LocationController extends Controller
         $this->contentService = $contentService;
     }
 
-    public function suggestedAction(Request $request, $content)
+    public function suggestedAction(Request $request, $contentTypeIdentifier)
     {
-        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($content);
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
         $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, reset($this->languages));
 
-        if (!isset($this->contentConfiguration[$content])) {
-            $content = 'default';
+        if (!isset($this->contentConfiguration[$contentTypeIdentifier])) {
+            $contentTypeIdentifier = 'default';
         }
 
-        if (isset($this->contentConfiguration[$content])) {
-            $locations = $this->contentConfiguration[$content]['location'];
+        if (isset($this->contentConfiguration[$contentTypeIdentifier])) {
+            $locations = $this->contentConfiguration[$contentTypeIdentifier]['location'];
         } else {
             $locations = [];
         }
@@ -76,7 +76,7 @@ class LocationController extends Controller
             } catch (NotFoundException $e) {
                 // Skip and log invalid locations
                 if ($this->logger) {
-                    $this->logger->warning("Suggested location not found (content type: {$content}, location id: {$locationId}). Exception: " . $e->getMessage());
+                    $this->logger->warning("Suggested location not found (content config: {$contentTypeIdentifier}, location id: {$locationId}). Exception: " . $e->getMessage());
                 }
             }
         }

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -2,5 +2,4 @@ contentonthefly.location_controller.suggested:
     path: /contentonthefly/locations/{content}
     defaults:
         _controller: contentonthefly.controller.location:suggestedAction
-        content: 'default'
     methods: [GET]

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 contentonthefly.location_controller.suggested:
-    path: /contentonthefly/locations/{content}
+    path: /contentonthefly/locations/{contentTypeIdentifier}
     defaults:
         _controller: contentonthefly.controller.location:suggestedAction
     methods: [GET]


### PR DESCRIPTION
There was issue with fallback, because in the end it tried to get content type with identifier `default` (obviously missing). I moved creating dummy content type above fallback check, so first it checks if asked content type exists (404 when it doesn't) and eventually later it overwrites identifier with `default` if there's no configuration for it. It also implies that content identifier is required router parameter, as we have to know which content type user is trying to create. 

Variable `$content` could be potentially misleading so I renamed it to `$contentIdentifier`.
