### PR TITLE
EZS-805: Preselected content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Platform UI Content on the Fly feature
 
 4. Clear cache and setup assets with `$ composer run-script post-update-cmd`
 
-   *(if you use prod env make sure that is set with `$ export SYMFONY_ENV=prod` first)*.
+   *(if you use prod env make sure that it is set with `$ export SYMFONY_ENV=prod` first)*.
 
 
 ## Configuration
@@ -62,17 +62,17 @@ parameters:
 ```
 
 ## Default location for content type
-If suggested locations are given for content type (or default) the first location in the list will be preselected as location.
+If suggested locations are provided for a Content Type (or default) the first location in the list will be preselected.
 
 ## Preselected content type
-To set the content type you have to provide 'contentTypeIdentifier' in the config of the 'contentDiscover' event.
+To set the Content Type you have to provide the 'contentTypeIdentifier' in the config of the 'contentDiscover' event.
 Example:
 ```javascript
 /**
 * ...
 * @param config.visibleMethod {String} which tab should be open. Default: 'browse', possible values: 'browse', 'search', 'create'
 * @param config.contentTypeIdentifier {String} content type identifier. Default: none, example values: 'image', 'blog', 'article', 'blog_post'
-*        config.contentTypeIdentifier is limited to the Create tab, config that works across all tabs will be added in the future
+*                                     this parameter is limited to the Create tab, config that works across all tabs will be added in the future
 */
 app.fire('contentDiscover', {
     config: {

--- a/README.md
+++ b/README.md
@@ -60,3 +60,21 @@ parameters:
                 - 2     # /Home
                 - 43    # /Media
 ```
+
+## Preselected content type
+To set the content type you have to provide 'contentTypeIdentifier' in the config of the 'contentDiscover' event.
+Example:
+```javascript
+/**
+* ...
+* @param config.visibleMethod {String} which tab should be open. Default: 'browse', possible values: 'browse', 'search', 'create'
+* @param config.contentTypeIdentifier {String} content type identifier. Default: none, example values: 'image', 'blog', 'article', 'blog_post'
+*/
+app.fire('contentDiscover', {
+    config: {
+        // ...
+        visibleMethod: 'create',
+        contentTypeIdentifier: 'image'
+    }
+});
+```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ parameters:
                 - 43    # /Media
 ```
 
+## Default location for content type
+If suggested locations are given for content type (or default) the first location in the list will be preselected as location.
+
 ## Preselected content type
 To set the content type you have to provide 'contentTypeIdentifier' in the config of the 'contentDiscover' event.
 Example:
@@ -69,6 +72,7 @@ Example:
 * ...
 * @param config.visibleMethod {String} which tab should be open. Default: 'browse', possible values: 'browse', 'search', 'create'
 * @param config.contentTypeIdentifier {String} content type identifier. Default: none, example values: 'image', 'blog', 'article', 'blog_post'
+*        config.contentTypeIdentifier is limited to the Create tab, config that works across all tabs will be added in the future
 */
 app.fire('contentDiscover', {
     config: {

--- a/bundle/Resources/public/css/theme/views/content-creation.css
+++ b/bundle/Resources/public/css/theme/views/content-creation.css
@@ -5,6 +5,7 @@
 
 .ez-view-contentcreationview {
     text-align: left;
+    position: relative;
 }
 
 .ez-view-contentcreationview .cof-content-creation__header {
@@ -82,6 +83,7 @@
     background: #fdfdfd;
 }
 
+.ez-view-contentcreationview.is-loading:before,
 .ez-view-contentcreationview .is-loading:before {
     content: "";
     height: 100%;
@@ -91,8 +93,10 @@
     top: 0;
     left: 0;
     border-radius: 5px;
+    z-index: 5
 }
 
+.ez-view-contentcreationview.is-loading:after,
 .ez-view-contentcreationview .is-loading:after {
     content: '\f110';
     color: #3FB499;
@@ -101,6 +105,7 @@
     left: 50%;
     font-family: 'studiofont';
     animation: spin .7s infinite linear;
+    z-index: 5
 }
 
 .ez-view-contentcreationview .cof-btn--edit-location {

--- a/bundle/Resources/public/js/views/cof-contentcreationview.js
+++ b/bundle/Resources/public/js/views/cof-contentcreationview.js
@@ -147,17 +147,17 @@ YUI.add('cof-contentcreationview', function (Y) {
          * @param event {Object} event facade
          */
         _getContentTypes: function (event) {
-            var eventNewVal = event.newVal,
+            var displayed = event.newVal,
                 container = this.get('container'),
                 contentTypeContainer = container.one(SELECTOR_CONTENT_TYPE),
                 nextButton = container.one(SELECTOR_NEXT_BUTTON),
                 restoreFormState = this.get('restoreFormState');
 
-            if (!eventNewVal && !restoreFormState) {
+            if (!displayed && !restoreFormState) {
                 this._resetFormState();
 
                 return;
-            } else if (eventNewVal && restoreFormState) {
+            } else if (displayed && restoreFormState) {
                 this.set('restoreFormState', false);
 
                 return;
@@ -175,6 +175,8 @@ YUI.add('cof-contentcreationview', function (Y) {
             /**
              * Fetches the content types data.
              * Listened in the cof.Plugin.createContentSelectContentType
+             *
+             * @event fetchContentTypes
              */
             this.fire('fetchContentTypes');
         },
@@ -246,12 +248,14 @@ YUI.add('cof-contentcreationview', function (Y) {
              * Fired to save the current state of Discovery Widget.
              * Listened in the cof.Plugin.CreateContentUniversalDiscovery
              *
+             * @event saveDiscoveryState
              */
             this.fire('saveDiscoveryState');
             /**
              * Fired to open new Discovery Widget.
-             * Listened in the cof.Plugin.createContentSelectContentType
+             * Listened in the cof.Plugin.selectContentType
              *
+             * @event openUniversalDiscoveryWidget
              */
             this.fire('openUniversalDiscoveryWidget');
 
@@ -266,9 +270,9 @@ YUI.add('cof-contentcreationview', function (Y) {
          * @param event {Object} event facade
          */
         _updateSelectedLocation: function (event) {
-            var eventNewVal = event.newVal,
-                locationPath = eventNewVal.location.get('path'),
-                contentInfo = eventNewVal.contentInfo,
+            var selectedLocation = event.newVal,
+                locationPath = selectedLocation.location.get('path'),
+                contentInfo = selectedLocation.contentInfo,
                 selectedName = contentInfo.get('name'),
                 pathSeparator = '/',
                 selectedPath = pathSeparator;
@@ -285,8 +289,10 @@ YUI.add('cof-contentcreationview', function (Y) {
              * Fired to set selected location where place the new content.
              * Listened in the eZS.Plugin.UniversalDiscoveryWidgetService
              *
+             * @event setParentLocation
+             * @param selectedLocation {Object} the selected location
              */
-            this.fire('setParentLocation', {selectedLocation: eventNewVal.location});
+            this.fire('setParentLocation', {selectedLocation: selectedLocation.location});
 
             this._enableFinishButton();
 
@@ -392,6 +398,8 @@ YUI.add('cof-contentcreationview', function (Y) {
              * Fired to fetch a list of suggested locations.
              * Listened in the cof.Plugin.CreateContentUniversalDiscovery
              *
+             * @event fetchSuggestedLocations
+             * @param event {eZ.ContentType} the seleceted content type
              */
             this.fire('fetchSuggestedLocations', event);
 
@@ -538,7 +546,8 @@ YUI.add('cof-contentcreationview', function (Y) {
                          * Fired to prepare content model for content type.
                          * Listened in the eZS.Plugin.SelectCreateContent
                          *
-                         * @param contentType {Object} the content type model
+                         * @event prepareContentModel
+                         * @param contentType {eZ.ContentType} the content type model
                          */
                         contentTypeSelector.fire('prepareContentModel', {contentType: contentType});
                     }

--- a/bundle/Resources/public/js/views/cof-contenttypeselectorview.js
+++ b/bundle/Resources/public/js/views/cof-contenttypeselectorview.js
@@ -74,8 +74,9 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
 
             /**
              * Informs an item is selected.
-             * Listened in the eZS.CreateContentPopupView
+             * Listened in the cof.ContentCreationView
              *
+             * @event itemSelected
              * @param text {String} text to show on remove button
              */
             this.fire('itemSelected', {text: event.text});
@@ -196,7 +197,8 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
               * Fired to prepare content model for content type.
               * Listened in the eZS.Plugin.SelectCreateContent
               *
-              * @param contentType {Object} the content type model
+              * @event prepareContentModel
+              * @param contentType {eZ.ContentType} the content type model
               */
              this.fire('prepareContentModel', {contentType: type});
          },

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
@@ -91,8 +91,22 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
         _closeDiscoveryWidget: function (event) {
             var host = this.get('host');
 
+            /**
+             * Fired to confirm selection in the universal discovery widget.
+             * Listened in the eZ.UniversalDiscoveryView
+             *
+             * @event confirmSelectedContent
+             * @param selection {Object} the selected content
+             */
             host.fire('confirmSelectedContent', {selection: event});
 
+            /**
+             * Fired to inform thaht content is discovered.
+             * Listened in the eZ.Plugin.UniversalDiscovery
+             *
+             * @event contentDiscovered
+             * @param selection {Object} the selected content
+             */
             host.fire('contentDiscovered', {
                 selection: host.get('selection'),
             });

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
@@ -106,10 +106,10 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
          * @param event {Object} event facade
          */
         _setContentTypeIdentifier: function (event) {
-            var eventNewVal = event.newVal;
+            var contentTypeIdentifier = event.newVal;
 
-            if (eventNewVal && eventNewVal !== event.prevVal) {
-                this.get('tabCreateView').get('contentCreationView').set('contentTypeIdentifier', eventNewVal);
+            if (contentTypeIdentifier && contentTypeIdentifier !== event.prevVal) {
+                this.get('tabCreateView').get('contentCreationView').set('contentTypeIdentifier', contentTypeIdentifier);
             }
         },
     }, {

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
@@ -33,6 +33,7 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
             host.on('*:restoreDiscoveryWidget', this._restoreDiscoveryWidgetState, this);
             host.on('*:contentLoaded', this._closeDiscoveryWidget, this);
             host.on('activeChange', this._toggleTabCreateVisibility, this);
+            host.on('contentTypeIdentifierChange', this._setContentTypeIdentifier, this);
         },
 
         /**
@@ -95,6 +96,21 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
             host.fire('contentDiscovered', {
                 selection: host.get('selection'),
             });
+        },
+
+        /**
+         * Sets content type identifier.
+         *
+         * @protected
+         * @method _setContentTypeIdentifier
+         * @param event {Object} event facade
+         */
+        _setContentTypeIdentifier: function (event) {
+            var eventNewVal = event.newVal;
+
+            if (eventNewVal && eventNewVal !== event.prevVal) {
+                this.get('tabCreateView').get('contentCreationView').set('contentTypeIdentifier', eventNewVal);
+            }
         },
     }, {
         NS: 'createContentUniversalDiscoveryWidgetPlugin',

--- a/bundle/Resources/public/js/views/plugins/cof-selectcontenttypeplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-selectcontenttypeplugin.js
@@ -40,6 +40,13 @@ YUI.add('cof-selectcontenttypeplugin', function (Y) {
                                 event.target.set('suggestedLocations', result);
                             })
                             .catch(function (error) {
+                                /**
+                                 * Displays a notification bar with error message.
+                                 * Listened by eZ.PlatformUIApp
+                                 *
+                                 * @event notify
+                                 * @param notification {Object} notification data
+                                 */
                                 host.fire('notify', {
                                     notification: {
                                         text: error.message || 'An unexpected error has occurred',


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZS-805

**Screencast**
![cof-preselected-content-type](https://cloud.githubusercontent.com/assets/12594013/16229320/68f929d4-37bc-11e6-9fb4-15f87f75c50f.gif)

Note: This PR doesn't change the behavior of the image button, it only provide possibility to configure it.

**Instruction for test/review/doc**
To set the content type you have to provide 'contentTypeIdentifier' in the config of the 'contentDiscover' event. 
Example:

``` javascript
/**
* ...
* @param config.visibleMethod {String} which tab should be open. Default: 'browse', possible values: 'browse', 'search', 'create'
* @param config.contentTypeIdentifier {String} content type identifier. Default: none, example values: 'image', 'blog', 'article', 'blog_post'
*/
app.fire('contentDiscover', {
    config: {
        // ...
        visibleMethod: 'create',
        contentTypeIdentifier: 'image'
    }
});
```
