### PR TITLE
EZP-25951: Rich text controls not visible when creating content on the fly

### DIFF
--- a/bundle/Resources/public/css/views/general.css
+++ b/bundle/Resources/public/css/views/general.css
@@ -14,3 +14,7 @@
 .cof-index-reset {
     z-index: auto !important;
 }
+
+.cof-index-forced {
+    z-index: 5 !important;
+}

--- a/bundle/Resources/public/js/views/cof-contentcreationview.js
+++ b/bundle/Resources/public/js/views/cof-contentcreationview.js
@@ -14,6 +14,7 @@ YUI.add('cof-contentcreationview', function (Y) {
 
     var CLASS_HIDDEN = 'cof-is-hidden',
         CLASS_LOADING = 'is-loading',
+        CLASS_INDEX_FORCED = 'cof-index-forced',
         CLASS_CONTENT_CREACTION = 'cof-content-creation',
         CLASS_TOOLTIP = CLASS_CONTENT_CREACTION + '__tooltip',
         CLASS_BUTTON = 'cof-btn',
@@ -33,6 +34,7 @@ YUI.add('cof-contentcreationview', function (Y) {
         SELECTOR_ITEM_SELECTED = '.ez-selection-filter-item-selected',
         SELECTOR_SUGGESTED_LOCATIONS = SELECTOR_CONTENT_CREACTION + '__suggested-locations',
         SELECTOR_SUGGESTED_ITEM = SELECTOR_SUGGESTED_LOCATIONS + '__item',
+        SELECTOR_UDW_CONTAINER = '.ez-universaldiscovery-container',
         ATTR_DESCRIPTION = 'data-description',
         ATTR_ID = 'data-id',
         SELECTOR_EDIT_LOCATION_BUTTON = SELECTOR_BUTTON +  '--edit-location',
@@ -348,6 +350,8 @@ YUI.add('cof-contentcreationview', function (Y) {
 
             createContentView.set('active', true);
 
+            Y.one(SELECTOR_UDW_CONTAINER).addClass(CLASS_INDEX_FORCED);
+
             this._hideButtons(createContentView);
         },
 
@@ -380,6 +384,7 @@ YUI.add('cof-contentcreationview', function (Y) {
             var container = this.get('container');
 
             container.one(SELECTOR_CONTENT_CREATOR).addClass(CLASS_HIDDEN);
+            Y.one(SELECTOR_UDW_CONTAINER).removeClass(CLASS_INDEX_FORCED);
 
             if (hideWidget) {
                 this.set('displayed', false);

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
@@ -12,8 +12,10 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
     Y.namespace('cof.Plugin');
 
     var CLASS_HIDDEN = 'cof-is-hidden',
+        CLASS_INDEX_FORCED = 'cof-index-forced',
         SELECTOR_TAB_CREATE = '[href="#ez-ud-create"]',
-        SELECTOR_TAB_LABEL = '.ez-tabs-label';
+        SELECTOR_TAB_LABEL = '.ez-tabs-label',
+        SELECTOR_UDW_CONTAINER = '.ez-universaldiscovery-container';
 
     /**
      * Content on the Fly plugin. Extends the Universal Discovery Widget View
@@ -90,6 +92,8 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
          */
         _closeDiscoveryWidget: function (event) {
             var host = this.get('host');
+
+            Y.one(SELECTOR_UDW_CONTAINER).removeClass(CLASS_INDEX_FORCED);
 
             /**
              * Fired to confirm selection in the universal discovery widget.


### PR DESCRIPTION
**Jira ticke:** https://jira.ez.no/browse/EZP-25951

**Description**
The Rich text controls didn't show because of the z-index issue.
