### PR TITLE
EZP-26061: Richtext field embedded content on-the-fly cannot be created

### DIFF
--- a/bundle/Resources/public/css/views/general.css
+++ b/bundle/Resources/public/css/views/general.css
@@ -16,7 +16,7 @@
 }
 
 .cof-index-forced {
-    z-index: 5 !important;
+    z-index: 1030 !important;
 }
 
 .cof-is-active {


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-26061

**Description:**
The issue was caused by z-index. The action bar was displayed from "editing content" not from "creating content", so on click "publish" the editing content was published.
