### PR TITLE
EZP-26011: Directly load the main Location instead of searching for it

### DIFF
--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
@@ -232,18 +232,19 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
             var udwService = this.get('host'),
                 selection = {
                     contentType: udwService.get('contentType'),
-                };
+                },
+                mainLocation = new Y.eZ.Location();
 
             if ( udwService.get('parameters').loadContent ) {
                 selection.content = event.content;
             }
 
-            event.content.loadLocations({api: udwService.get('capi')}, function (error, locations) {
-                selection.location = locations[0];
-                selection.contentInfo = locations[0].get('contentInfo');
+            mainLocation.set('id', event.content.get('resources').MainLocation);
+            mainLocation.load({api: udwService.get('capi')}, function (error) {
+                selection.location = mainLocation;
+                selection.contentInfo = mainLocation.get('contentInfo');
 
                 udwService.get('app').set('loading', false);
-
                 udwService.get('eventTarget').fire('contentLoaded', selection);
             });
         },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26011
# Description

That's an additional fix for EZP-26011 (in addition to https://github.com/ezsystems/PlatformUIBundle/pull/642 and https://github.com/ezsystems/content-on-the-fly-prototype-bundle/pull/15) to avoid using the search engine to load the Location of the Content item that was just created.
# Tests

manual tests
