### PR TITLE
EZS-1160: Content on the fly shows undefined when content type description is empty

### DIFF
--- a/bundle/Resources/public/js/views/cof-contenttypeselectorview.js
+++ b/bundle/Resources/public/js/views/cof-contenttypeselectorview.js
@@ -67,7 +67,9 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
                     if (contentTypeItemId === contentType.get('id')) {
                         var description = contentType.get('descriptions')[contentType.get('mainLanguageCode')];
 
-                        contentTypeItem.setAttribute(ATTR_DESCRIPTION, description);
+                        if (description) {
+                            contentTypeItem.setAttribute(ATTR_DESCRIPTION, description);
+                        }
                     }
                 });
             });


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZS-1160