### PR TITLE
Override Bundle::getContainerExtension to disable LogicException with extension name

### DIFF
--- a/bundle/EzSystemsEzContentOnTheFlyBundle.php
+++ b/bundle/EzSystemsEzContentOnTheFlyBundle.php
@@ -5,9 +5,18 @@
  */
 namespace EzSystems\EzContentOnTheFlyBundle;
 
+use EzSystems\EzContentOnTheFlyBundle\DependencyInjection\ContentOnTheFlyExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsEzContentOnTheFlyBundle extends Bundle
 {
     protected $name = 'ContentOnTheFlyBundle';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainerExtension()
+    {
+        return new ContentOnTheFlyExtension();
+    }
 }


### PR DESCRIPTION
When doing a Composer install/update, I get the following exception:

```
[LogicException]
Users will expect the alias of the default extension of a bundle to be the underscored version of the bundle name ("ez_systems_ez_content_on_the_fly"). You can override "Bundle::getContainerExtension()" if you want to use "content_on_the_fly" or another alias.
```

This PR removes the exception by overriding the Bundle class method that generates the exception.

The alternative is to properly name the extension alias, but that is a breaking change.