### PR TITLE
EZS-1395: Send for review stuck when using content on the fly

### DIFF
--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
@@ -269,14 +269,20 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
          * @param {eZ.ViewService} service
          */
         setNextViewServiceParameters: function (service) {
-            var host = this.get('host');
+            var host = this.get('host'),
+                content = host.get('content'),
+                languageCode = host.get('languageCode');
+
+            if (content && !content.get('mainLanguageCode')) {
+                content.set('mainLanguageCode', languageCode);
+            }
 
             if (host.get('parentLocation') && service instanceof Y.eZ.ContentCreateViewService) {
                 service.setAttrs({
                     parentLocation: host.get('parentLocation'),
-                    parentContent: host.get('content'),
+                    parentContent: content,
                     contentType: host.get('contentType'),
-                    languageCode: host.get('languageCode')
+                    languageCode: languageCode
                 });
             }
         },


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZS-1395

**Description**
- This bug is coused by fixing the `parentContent` from `host.get('contentType')` (which was wrong) to `host.get('content')` - in this PR https://github.com/ezsystems/content-on-the-fly-prototype-bundle/pull/22
- But as the content model is created couple line above (https://github.com/ezsystems/content-on-the-fly-prototype-bundle/blob/master/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js#L186), it doesn't have the `mainLanguageCode` setted. (And as I understand `publish` content set it, but saving draft doesn't)
