### PR TITLE
EZP-27096: Create using content-on-the-fly is not respecting non-containers

### DIFF
--- a/bundle/Resources/public/css/theme/views/content-type.css
+++ b/bundle/Resources/public/css/theme/views/content-type.css
@@ -21,3 +21,11 @@
     border-width: 7px 13px 7px 0;
     border-color: transparent #ddd transparent transparent;
 }
+
+.ez-view-contenttypeselectorview .cof-content-creation__tooltip--error {
+    border-color: #F00;
+}
+
+.ez-view-contenttypeselectorview .cof-content-creation__tooltip--error:before {
+    border-color: transparent #F00 transparent transparent;
+}

--- a/bundle/Resources/public/js/views/cof-contenttypeselectorview.js
+++ b/bundle/Resources/public/js/views/cof-contenttypeselectorview.js
@@ -14,6 +14,7 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
 
     var CLASS_HIDDEN = 'cof-is-hidden',
         CLASS_INVISIBLE = 'cof-invisible',
+        CLASS_TOOLTIP_ERROR = 'cof-content-creation__tooltip--error',
         SELECTOR_ITEM_SELECTED = '.ez-selection-filter-item-selected',
         SELECTOR_CONTENT_TYPE_LIST = '.ez-contenttypeselector-list',
         SELECTOR_TOOLTIP = '.cof-content-creation__tooltip',
@@ -127,6 +128,7 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
                 tooltip.setHTML(selectedItem.getAttribute(ATTR_DESCRIPTION));
 
                 tooltip[methodName](CLASS_HIDDEN);
+                tooltip.removeClass(CLASS_TOOLTIP_ERROR);
             }
         },
 
@@ -204,6 +206,23 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
               */
              this.fire('prepareContentModel', {contentType: type});
          },
+
+         /**
+          * Show content type error.
+          *
+          * @method showContentTypeError
+          * @return {cof.ContentTypeSelectorView} the view itself
+          */
+         showContentTypeError: function () {
+            var tooltip = this.get('container').one(SELECTOR_TOOLTIP);
+
+            tooltip.setHTML(this.get('errorMessage'));
+
+            tooltip.addClass(CLASS_TOOLTIP_ERROR);
+            tooltip.removeClass(CLASS_HIDDEN);
+
+            return this;
+         },
     }, {
         ATTRS: {
             /**
@@ -212,7 +231,18 @@ YUI.add('cof-contenttypeselectorview', function (Y) {
              * @attribute selectedContentType
              * @type Object
              */
-            selectedContentType: {}
+            selectedContentType: {},
+
+            /**
+             * The error message
+             *
+             * @attribute errorMessage
+             * @type String
+             */
+            errorMessage: {
+                value: 'The Content item was correctly created but was deleted because unfortunately it can not be used here, ' +
+                    'choose or create another Content item.'
+            }
         }
     });
 });

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryplugin.js
@@ -123,6 +123,14 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
 
             Y.one(SELECTOR_UDW_CONTAINER).removeClass(CLASS_INDEX_FORCED);
 
+            if (!host.get('isSelectable')(event)) {
+                event.target.showContentTypeError();
+
+                this._fireDeleteContentEvent(event.content);
+
+                return;
+            }
+
             /**
              * Fired to confirm selection in the universal discovery widget.
              * Listened in the eZ.UniversalDiscoveryView
@@ -141,6 +149,26 @@ YUI.add('cof-createcontent-universaldiscoveryplugin', function (Y) {
              */
             host.fire('contentDiscovered', {
                 selection: host.get('selection'),
+            });
+        },
+
+        /**
+         * Fires an event to delete content.
+         *
+         * @protected
+         * @method _fireDeleteContentEvent
+         * @param content {Object} the content
+         */
+        _fireDeleteContentEvent: function (content) {
+            /**
+             * Fired to delete content.
+             * Listened in the cof.Plugin.CreateContentUniversalDiscoveryService
+             *
+             * @event deleteContent
+             * @param content {Object} the content
+             */
+            this.get('host').fire('deleteContent', {
+                content: content
             });
         },
 

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
@@ -28,6 +28,7 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
             this.onHostEvent('*:prepareContentModel', this._loadContentTypeData, this);
             this.onHostEvent('*:setParentLocation', this._setParentLocation, this);
             this.onHostEvent('*:publishedDraft', this._loadContentLocation, this);
+            this.onHostEvent('*:deleteContent', this._deleteContent, this);
         },
 
         /**
@@ -63,7 +64,9 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
                     title: this.get('discoveryWidgetTitle'),
                     multiple: false,
                     contentDiscoveredHandler: Y.bind(this._setSelectedLocation, this, target),
-                    isSelectable: function () {return true;},
+                    isSelectable: function (contentStruct) {
+                        return contentStruct.contentType.get('isContainer');
+                    },
                     forceVisibleMethod: true,
                     hideTabCreate: true
                 },
@@ -136,7 +139,7 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
              *
              * @event contentDiscover
              */
-            app.fire('contentDiscover');
+            app.fire('contentDiscover', {config: {}});
         },
 
         /**
@@ -241,15 +244,12 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
          */
         _loadContentLocation: function (event) {
             var udwService = this.get('host'),
-                udwParameters = udwService.get('parameters') ? udwService.get('parameters') : this._savedDiscoveryAttributes,
                 selection = {
                     contentType: udwService.get('contentType'),
                 },
                 mainLocation = new Y.eZ.Location();
 
-            if ( udwParameters.loadContent ) {
-                selection.content = event.content;
-            }
+            selection.content = event.content;
 
             mainLocation.set('id', event.content.get('resources').MainLocation);
             mainLocation.load({api: udwService.get('capi')}, function (error) {
@@ -285,6 +285,17 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
                     languageCode: languageCode
                 });
             }
+        },
+
+        /**
+         * Deletes given content.
+         *
+         * @method _deleteContent
+         * @param event {Object} event facade
+         * @param event.content {Object} the content
+         */
+        _deleteContent: function (event) {
+            event.content.delete({api: this.get('host').get('capi')}, function () {});
         },
     }, {
         NS: 'CreateContentUniversalDiscoveryServicePlugin',


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-27096

**TO DO**
- [x] ~~added flag if content type should be a container (used in copy)~~
- [x] prevent from choosing non-container content when choosing location
- [x] use isSelectable to check if created content can be selected
- [x] manual tests