### PR TITLE
Fix EZP-27541: Unable to change language in embed content create view

### DIFF
--- a/bundle/Resources/public/js/views/cof-contentcreationview.js
+++ b/bundle/Resources/public/js/views/cof-contentcreationview.js
@@ -353,9 +353,23 @@ YUI.add('cof-contentcreationview', function (Y) {
                      .removeClass(CLASS_HIDDEN);
 
             createContentView.set('active', true);
-
+            createContentView.after('versionChange', this._setContentLanguage.bind(this, createContentView));
             Y.one(SELECTOR_UDW_CONTAINER).addClass(CLASS_INDEX_FORCED);
 
+            this._hideButtons(createContentView);
+        },
+
+        /**
+         * Updates the content language.
+         *
+         * @protected
+         * @method _setContentLanguage
+         * @param createContentView {Object} the view instance
+         * @param event {Object} event facade
+         */
+        _setContentLanguage: function (createContentView, event) {
+            this.get('contentTypeSelectorView')
+                .set('languageCode', createContentView.get('languageCode'));
             this._hideButtons(createContentView);
         },
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27541

# Description

This PR adds the ability to change the language in content created via content-on-the-fly module. Code based on https://github.com/ezsystems/PlatformUIBundle/blob/master/Resources/public/js/views/services/ez-contentcreateviewservice.js#L134:L198 

# Steps to reproduce
1. Create an article. In French for example
2. In the Body field, click on + button contextual menu in the editor and choose Embed.
3. Click on Create tab, choose any content type, a location and click on Confirm selection button.
4. When the create mode of the future embedded content type appears, nothing happens when click on change language to switch the language.
 