### PR TITLE
EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_annotation_without_dot' => false,
         'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/bundle/Features/Context/ContentOnTheFlyContext.php
+++ b/bundle/Features/Context/ContentOnTheFlyContext.php
@@ -17,7 +17,6 @@ class ContentOnTheFlyContext implements Context
     private $contentOnTheFly;
 
     /** @BeforeScenario
-     *
      * @param BeforeScenarioScope $scope Behat scope
      */
     public function getFlexWfContext(BeforeScenarioScope $scope)

--- a/bundle/Features/Context/ContentOnTheFlyPopup.php
+++ b/bundle/Features/Context/ContentOnTheFlyPopup.php
@@ -15,7 +15,7 @@ class ContentOnTheFlyPopup
     public $displayedSuggestedLocations = ['/Media', '/Home'];
 
     /** @var string Location selected by the user (defaults to /Home) */
-    public $selectedLocation = "/Home";
+    public $selectedLocation = '/Home';
 
     /** @var \EzSystems\FlexWorkflowBundle\Features\Context\FlexWf executing context */
     private $context;
@@ -43,8 +43,8 @@ class ContentOnTheFlyPopup
 
     /** @var string[] Array of available parent location of Content on the fly popup and their selectors */
     private static $parentLocations = [
-        "Dashboard" => ".ez-view-dashboardblocksview",
-        "UDW" => ".ez-view-universaldiscoveryview",
+        'Dashboard' => '.ez-view-dashboardblocksview',
+        'UDW' => '.ez-view-universaldiscoveryview',
     ];
 
     /**
@@ -168,7 +168,7 @@ class ContentOnTheFlyPopup
     }
 
     /**
-     * Waits until the displayed location is the same as set by the user
+     * Waits until the displayed location is the same as set by the user.
      *
      * @param string $location Expected selected location
      */

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ezsystems/ezpublish-kernel": "^6.3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.1"
+        "friendsofphp/php-cs-fixer": "~2.7.1"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.1"
     },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.1.x-dev"


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161)

This PR updates `.php_cs` config and aligns CS.
To simplify fixing code it adds dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Update CS
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`
- [x] Add missing `.gitignore` file // out of scope, but kind of related