### PR TITLE
EZP-28713: Create using content-on-the-fly is not respecting current language 

### DIFF
--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
@@ -190,14 +190,18 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
             var content = new Y.eZ.Content(),
                 version = new Y.eZ.Version(),
                 type = event.contentType,
-                mainLanguageCode = type.get('mainLanguageCode'),
                 host = this.get('host'),
                 user = host.get('app').get('user'),
+                activeViewService = host.get('app').get('activeViewService'),
                 target = event.target,
                 defaultFields = {},
-                languageCode;
+                languageCode = type.get('mainLanguageCode');
 
-            content.set('name', 'New "' + type.get('names')[mainLanguageCode] + '"');
+            if (activeViewService.name === 'contentCreateViewService' || activeViewService.name === 'contentEditViewService') {
+                languageCode = activeViewService.get('languageCode');
+            }
+
+            content.set('name', 'New "' + type.get('names')[languageCode] + '"');
 
             Y.Object.each(type.get('fieldDefinitions'), function (fieldDef, identifier) {
                 defaultFields[identifier] = {
@@ -205,11 +209,6 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
                     fieldValue: fieldDef.defaultValue,
                 };
             });
-
-            languageCode = mainLanguageCode;
-            if (host.get('request').params.languageCode) {
-                languageCode = host.get('request').params.languageCode;
-            }
 
             host.setAttrs({
                 content: content,

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
@@ -191,8 +191,9 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
                 version = new Y.eZ.Version(),
                 type = event.contentType,
                 host = this.get('host'),
-                user = host.get('app').get('user'),
-                activeViewService = host.get('app').get('activeViewService'),
+                app = host.get('app'),
+                user = app.get('user'),
+                activeViewService = app.get('activeViewService'),
                 target = event.target,
                 defaultFields = {},
                 languageCode = type.get('mainLanguageCode');

--- a/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
+++ b/bundle/Resources/public/js/views/plugins/cof-createcontent-universaldiscoveryserviceplugin.js
@@ -194,7 +194,8 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
                 host = this.get('host'),
                 user = host.get('app').get('user'),
                 target = event.target,
-                defaultFields = {};
+                defaultFields = {},
+                languageCode;
 
             content.set('name', 'New "' + type.get('names')[mainLanguageCode] + '"');
 
@@ -205,10 +206,15 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
                 };
             });
 
+            languageCode = mainLanguageCode;
+            if (host.get('request').params.languageCode) {
+                languageCode = host.get('request').params.languageCode;
+            }
+
             host.setAttrs({
                 content: content,
                 version: version,
-                languageCode: mainLanguageCode,
+                languageCode: languageCode,
                 contentType: type,
                 eventTarget: target
             });
@@ -216,7 +222,7 @@ YUI.add('cof-createcontent-universaldiscoveryserviceplugin', function (Y) {
             target.setAttrs({
                 content: content,
                 version: version,
-                languageCode: mainLanguageCode,
+                languageCode: languageCode,
                 owner: user,
                 user: user
             });


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28713

## Description

This PR contains patch for not respected current language when user is creating content via content-on-the-fly

## Steps to reproduce

> 1. Create new language in admin panel via PlatformUI
> 2. Create new content using this new language
> 3. Try to embed a content in RichText field by creating another content
> 4. Notice that default language of embedded content doesn't match its parents
